### PR TITLE
Add `EG_SYSTEM_CONFIG_PATH` and `EG_GATEWAY_CONFIG_PATH` settings

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -16,12 +16,14 @@ class Config {
     this.configTypes = {
       system: {
         baseFilename: 'system.config',
+        pathVar: 'EG_SYSTEM_CONFIG_PATH',
         validator: schemas.register('config', 'system.config', require('./schemas/system.config.json')),
         pathProperty: 'systemConfigPath',
         configProperty: 'systemConfig'
       },
       gateway: {
         baseFilename: 'gateway.config',
+        pathVar: 'EG_GATEWAY_CONFIG_PATH',
         validator: schemas.register('config', 'gateway.config', require('./schemas/gateway.config.json')),
         pathProperty: 'gatewayConfigPath',
         configProperty: 'gatewayConfig'
@@ -31,16 +33,18 @@ class Config {
 
   loadConfig(type) {
     const configType = this.configTypes[type];
-    let configPath = this[configType.pathProperty] || path.join(process.env.EG_CONFIG_DIR, `${configType.baseFilename}.yml`);
-    let config;
+    let configPath = this[configType.pathProperty] || process.env[configType.pathVar];
 
-    try {
-      fs.accessSync(configPath, fs.constants.R_OK);
-    } catch (e) {
-      log.verbose(`Unable to access ${configPath} file. Trying with the json counterpart.`);
-      configPath = path.join(process.env.EG_CONFIG_DIR, `${configType.baseFilename}.json`);
+    if (!configPath) {
+      try {
+        configPath = path.join(process.env.EG_CONFIG_DIR, `${configType.baseFilename}.yml`);
+        fs.accessSync(configPath, fs.constants.R_OK);
+      } catch (e) {
+        configPath = path.join(process.env.EG_CONFIG_DIR, `${configType.baseFilename}.json`);
+      }
     }
 
+    let config;
     try {
       config = yamlOrJson.load(envReplace(fs.readFileSync(configPath, 'utf8'), process.env));
     } catch (err) {


### PR DESCRIPTION
Allows the location of main configuration files to be specified via environment variables.